### PR TITLE
fix: compatible with no script or data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,11 @@ export function transformCode(sourceCode: string) {
       );
     }
 
-    const preScript = result.script.content;
+    let preScript = "export default {}";
+    if (result.script && result.script.content){
+      preScript = result.script.content;
+    }
+    
     const preTemplate = result.template.content;
     const styles = result.styles;
 

--- a/src/reactTemplateBuilder.ts
+++ b/src/reactTemplateBuilder.ts
@@ -18,7 +18,7 @@ export default function reactTemplateBuilder(app: App) {
 
   const node = buildRequire({
     NAME: t.identifier(formatComponentName(app.script.name)),
-    STATE: t.objectExpression(app.script.data._statements)
+    STATE: t.objectExpression(app.script.data._statements || [])
   });
 
   return t.file(t.program([node as any]));


### PR DESCRIPTION
There will be an error if no script or data in SFC.

Reproduction: 

```vue
<template>
  <div></div>
</template>
```

```vue
<template>
  <div></div>
</template>
<script>
export default {};
</script>
```